### PR TITLE
Fix RouterMockImp

### DIFF
--- a/ApplicationCoordinatorTests/Router/RouterMock.swift
+++ b/ApplicationCoordinatorTests/Router/RouterMock.swift
@@ -73,6 +73,10 @@ final class RouterMockImp: RouterMock {
         navigationStack.append(controller)
     }
     
+    func setRootModule(_ module: Presentable?, hideBar: Bool) {
+        assertionFailure("This method is not used.")
+    }
+
     func popToRootModule(animated: Bool) {
         guard let first = navigationStack.first else { return }
         


### PR DESCRIPTION
@AndreyPanov 

RouterMockImp does not confirm to protocol Router, so I implement setRootModule(_:hideBar:) and it pass the Test.

And your sample app is very helpful for me. Thank you.