### PR TITLE
Fix a possible ARC bug & Dependency-cleaning upgraded

### DIFF
--- a/ApplicationCoordinator/Flows/MainTabbarFlow/TabbarCoordinator.swift
+++ b/ApplicationCoordinator/Flows/MainTabbarFlow/TabbarCoordinator.swift
@@ -18,8 +18,8 @@ class TabbarCoordinator: BaseCoordinator {
     return { [unowned self] navController in
       if navController.viewControllers.isEmpty == true {
         let itemCoordinator = self.coordinatorFactory.makeItemCoordinator(navController: navController)
-        itemCoordinator.start()
         self.addDependency(itemCoordinator)
+        itemCoordinator.start()
       }
     }
   }
@@ -28,8 +28,8 @@ class TabbarCoordinator: BaseCoordinator {
     return { [unowned self] navController in
       if navController.viewControllers.isEmpty == true {
         let settingsCoordinator = self.coordinatorFactory.makeSettingsCoordinator(navController: navController)
-        settingsCoordinator.start()
         self.addDependency(settingsCoordinator)
+        settingsCoordinator.start()
       }
     }
   }

--- a/ApplicationCoordinator/Flows/MainTabbarFlow/TabbarCoordinator.swift
+++ b/ApplicationCoordinator/Flows/MainTabbarFlow/TabbarCoordinator.swift
@@ -15,7 +15,7 @@ class TabbarCoordinator: BaseCoordinator {
   }
   
   private func runItemFlow() -> ((UINavigationController) -> ()) {
-    return { navController in
+    return { [unowned self] navController in
       if navController.viewControllers.isEmpty == true {
         let itemCoordinator = self.coordinatorFactory.makeItemCoordinator(navController: navController)
         itemCoordinator.start()
@@ -25,7 +25,7 @@ class TabbarCoordinator: BaseCoordinator {
   }
   
   private func runSettingsFlow() -> ((UINavigationController) -> ()) {
-    return { navController in
+    return { [unowned self] navController in
       if navController.viewControllers.isEmpty == true {
         let settingsCoordinator = self.coordinatorFactory.makeSettingsCoordinator(navController: navController)
         settingsCoordinator.start()

--- a/ApplicationCoordinator/Parents/BaseCoordinator.swift
+++ b/ApplicationCoordinator/Parents/BaseCoordinator.swift
@@ -22,6 +22,10 @@ class BaseCoordinator: Coordinator {
       let coordinator = coordinator
       else { return }
     
+    // Clear child-coordinators recursively
+    if let coordinator = coordinator as? BaseCoordinator, !coordinator.childCoordinators.isEmpty {
+      coordinator.childCoordinators.forEach({ coordinator.removeDependency($0) })
+    }
     for (index, element) in childCoordinators.enumerated() {
       if element === coordinator {
         childCoordinators.remove(at: index)

--- a/ApplicationCoordinator/Parents/BaseCoordinator.swift
+++ b/ApplicationCoordinator/Parents/BaseCoordinator.swift
@@ -10,9 +10,7 @@ class BaseCoordinator: Coordinator {
   
   // add only unique object
   func addDependency(_ coordinator: Coordinator) {
-    for element in childCoordinators {
-      if element === coordinator { return }
-    }
+    guard !childCoordinators.contains(where: { $0 === coordinator }) else { return }
     childCoordinators.append(coordinator)
   }
   
@@ -24,13 +22,13 @@ class BaseCoordinator: Coordinator {
     
     // Clear child-coordinators recursively
     if let coordinator = coordinator as? BaseCoordinator, !coordinator.childCoordinators.isEmpty {
-      coordinator.childCoordinators.forEach({ coordinator.removeDependency($0) })
+        coordinator.childCoordinators
+            .filter({ $0 !== coordinator })
+            .forEach({ coordinator.removeDependency($0) })
     }
-    for (index, element) in childCoordinators.enumerated() {
-      if element === coordinator {
+    for (index, element) in childCoordinators.enumerated() where element === coordinator {
         childCoordinators.remove(at: index)
         break
-      }
     }
   }
 }


### PR DESCRIPTION
After I've played with this solution in local I've found that the TabbarCoordinator leaks because of the handler blocks. 
After I've found that the removeDependency only clears the top level parent if it has children.

_ps.: Thanks for the opportunity to be my first pull-request ;)_